### PR TITLE
修改view-koa案列中 初始化nunjucks时 path参数未使用的bug

### DIFF
--- a/samples/node/web/koa/view-koa/app.js
+++ b/samples/node/web/koa/view-koa/app.js
@@ -31,7 +31,7 @@ if (! isProduction) {
 app.use(bodyParser());
 
 // add nunjucks as view:
-app.use(templating('view', {
+app.use(templating('views', {
     noCache: !isProduction,
     watch: !isProduction
 }));

--- a/samples/node/web/koa/view-koa/templating.js
+++ b/samples/node/web/koa/view-koa/templating.js
@@ -7,7 +7,7 @@ function createEnv(path, opts) {
         watch = opts.watch || false,
         throwOnUndefined = opts.throwOnUndefined || false,
         env = new nunjucks.Environment(
-            new nunjucks.FileSystemLoader('views', {
+            new nunjucks.FileSystemLoader(path, {
                 noCache: noCache,
                 watch: watch,
             }), {


### PR DESCRIPTION
按照廖老师代码的语义，templating函数的第一个参数应为模板路径，但是在实际new nunjucks模版的时候，使用的是固定路径"views",这里应为path参数
